### PR TITLE
Update monthly-report-for-oncall.yml

### DIFF
--- a/.github/workflows/monthly-report-for-oncall.yml
+++ b/.github/workflows/monthly-report-for-oncall.yml
@@ -7,9 +7,7 @@ on:
     branches:
       - master
   schedule:
-    # Send out the report every Friday at noon PST
-    # There isn't a simple cron to run on 1st monday before 2nd wednesday
-    - cron:  '0 20 * * 5'
+    - cron:  '35 * * * *'
 
 jobs:
   test:


### PR DESCRIPTION
Run on the 35th minute.

In lieu of a manual trigger, run the workflow on the 35th minute and then revert this change. 